### PR TITLE
Decrease memory footprint of the applitools plugin

### DIFF
--- a/plugins/applitools/src/main.ts
+++ b/plugins/applitools/src/main.ts
@@ -131,6 +131,7 @@ export default class ApplitoolsPlugin implements ProofPlugin, CLIPlugin {
         const eyes = this.visualSessions.get(testArgs.name);
         if (eyes) {
           await eyes.abortIfNotClosed();
+          this.visualSessions.delete(testArgs.name);
         }
       });
     });


### PR DESCRIPTION
After the test is done, we don't need to hold on to the eyes object which can be pretty large 