### PR TITLE
Issue 8 fix enabling default accessibility config

### DIFF
--- a/plugins/accessibility/src/main.ts
+++ b/plugins/accessibility/src/main.ts
@@ -18,15 +18,15 @@ const defaultAxeConfig: axe.Spec = {
   rules: [
     {
       id: 'color-contrast',
-      enabled: false
+      enabled: true
     },
     {
       id: 'duplicate-id',
-      enabled: false
+      enabled: true
     },
     {
       id: 'heading-order',
-      enabled: false
+      enabled: true
     },
     {
       id: 'label',

--- a/plugins/accessibility/src/main.ts
+++ b/plugins/accessibility/src/main.ts
@@ -14,26 +14,7 @@ type AxeBrowser = Browser & {
   getAxeReport: (root: string, config: axe.Spec) => Promise<any>;
 };
 
-const defaultAxeConfig: axe.Spec = {
-  rules: [
-    {
-      id: 'color-contrast',
-      enabled: true
-    },
-    {
-      id: 'duplicate-id',
-      enabled: true
-    },
-    {
-      id: 'heading-order',
-      enabled: true
-    },
-    {
-      id: 'label',
-      none: ['help-same-as-label', 'multiple-label']
-    }
-  ]
-};
+const defaultAxeConfig: axe.Spec = {};
 
 function createMessage(config: TestConfig, violations: axe.Result[]): string {
   let message = '\nAccessibility Errors: \n';


### PR DESCRIPTION
Resolving https://github.com/intuit/proof/issues/8 by hard-setting the default configs to true. Alternatively, I can also just clean up those false settings if the default is true. Please let me know which is preferred, thanks!