### PR TITLE
Wait for Root To Exist

### DIFF
--- a/packages/browser/src/main.ts
+++ b/packages/browser/src/main.ts
@@ -166,10 +166,8 @@ export default class BrowserFactory {
 
       const root = options.story ? '#root' : '#storybook-preview-iframe';
       logger.debug(`Using root element: ${root}`);
-      logger.debug(
-        `Waiting ${this.waitForRoot}ms for root element to be visible`
-      );
-      await browser.waitForVisible(root, this.waitForRoot);
+      logger.debug(`Waiting ${this.waitForRoot}ms for root element to exist`);
+      await browser.waitForExist(root, this.waitForRoot);
 
       if (!options.story) {
         logger.trace('Swapping to storybook iframe');


### PR DESCRIPTION
The current implementation waits for root to be visible using [waitForVisible](http://v4.webdriver.io/v3.4/api/utility/waitForVisible.html). This is causing problems on a modal component that uses portals. Since root is empty, the height is zero and the visibility check fails. 

Changing this to [waitForExists](http://v4.webdriver.io/v3.4/api/utility/waitForExist.html) fixes this for our use case.