### PR TITLE
Update Selenium Options

### DIFF
--- a/packages/browser/src/main.ts
+++ b/packages/browser/src/main.ts
@@ -89,7 +89,7 @@ export default class BrowserFactory {
             '--window-size=1280,800'
           ]
         }
-      : {};
+      : undefined;
 
     const base =
       gridOptions && gridOptions[normalGrid]
@@ -100,6 +100,7 @@ export default class BrowserFactory {
       ...base,
       sync: false,
       desiredCapabilities: {
+        acceptSslCerts: true,
         browserName: name,
         platform,
         version,

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -4,15 +4,14 @@ The majority of the configuration for `proof` is set through the `proof.config.j
 
 # Options
 
-|     name     |   type   |                                       description                                        | 
-| ------------ | -------- | ---------------------------------------------------------------------------------------- | 
-| plugins      | `array`  | An optional array of plugins to include in the *proof* instance. See [plugins](https://intuit.github.io/proof/#/./plugins/README) for more details |                                                 |
-| url          | `string` | The default storybook URL to test against | 
-| logLevel     | `info`, `debug`, `trace`, `stupid` | The default log-level to use. Any CLI option will override this | 
-| testMath     | `glob`   | A glob to use to look for tests. Defaults to `__automation__/**/*.test.js` | 
-| gridOptions  | `object<grid, object>` | A set of properties to include for *any* session created on that grid type | 
-| waitForRoot  | `number` | The number of milliseconds to wait for storybook to load. Defaults to 1000ms. | 
-
+| name        | type                               | description                                                                                                                                        |
+| ----------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| plugins     | `array`                            | An optional array of plugins to include in the _proof_ instance. See [plugins](https://intuit.github.io/proof/#/./plugins/README) for more details |  |
+| url         | `string`                           | The default storybook URL to test against                                                                                                          |
+| logLevel    | `info`, `debug`, `trace`, `stupid` | The default log-level to use. Any CLI option will override this                                                                                    |
+| testMath    | `glob`                             | A glob to use to look for tests. Defaults to `__automation__/**/*.test.js`                                                                         |
+| gridOptions | `object<grid, object>`             | A set of properties to include for _any_ session created on that grid type                                                                         |
+| waitForRoot | `number`                           | The number of milliseconds to wait for storybook to load. Defaults to 1000ms.                                                                      |
 
 ## gridOptions
 
@@ -24,11 +23,14 @@ Allows you to pass in options to set on each grid type when creating a browser s
 {
   gridOptions: {
     remote: {
-      url: 'sauce.proof.com',
-      apiKey: 'foo-bar'
+      host: 'sauce.proof.com',
+      protocol: 'https',
+      port: 443,
+      path: '/v1',
+      queryParams: { apikey: process.env['SAUCE_API_KEY'] }
     }
   }
 }
 ```
 
-This will set the remote grid to use `sauce.proof.com` and the API key `foo-bar`. *Note* these options will only apply if you're running the tests under this grid type. If running proofs locally (using the local-grid), these options won't be added.
+This will set the remote grid to use `sauce.proof.com` and the API key `foo-bar`. _Note_ these options will only apply if you're running the tests under this grid type. If running proofs locally (using the local-grid), these options won't be added.


### PR DESCRIPTION
Some small changes to the selenium config.

* Set ChromeOptions to be undefined if not needed, since empty object breaks some grids.
* Set a config option to skip past SSL warning screens by default.
* Update configuration documentation to be a little closer to common usage parameters.