### PR TITLE
Use Configuration object from eyes.webdriver

### DIFF
--- a/plugins/applitools/src/main.ts
+++ b/plugins/applitools/src/main.ts
@@ -3,9 +3,10 @@ import {
   Eyes,
   BatchInfo,
   VisualGridRunner,
-  Target
+  Target,
+  Configuration
 } from '@applitools/eyes.webdriverio';
-import { BrowserType, Configuration } from '@applitools/eyes-selenium';
+import { BrowserType } from '@applitools/eyes-selenium';
 import Proof, {
   ProofPlugin,
   TestHookArgs,

--- a/plugins/applitools/src/types/applitools-selenium.d.ts
+++ b/plugins/applitools/src/types/applitools-selenium.d.ts
@@ -1,24 +1,4 @@
 declare module '@applitools/eyes-selenium' {
-  export class Configuration {
-    public stitchMode: 'CSS';
-
-    constructor();
-
-    getBranchName(): string;
-    setBranchName(name: string): void;
-    getBaselineBranchName(): string;
-    setBaselineBranchName(name: string): void;
-    getParentBranchName(): string;
-    setParentBranchName(name: string): void;
-    setAppName(name: string): void;
-    setTestName(name: string): void;
-    setApiKey(key: string): void;
-    setForceFullPageScreenshot(force: boolean): void;
-    setHideScrollbars(hide: boolean): void;
-
-    addBrowser(width: number, height: number, browserType: BrowserType): void;
-  }
-
   type BrowserType = 'CHROME';
   export const BrowserType: Record<string, BrowserType>;
 }

--- a/plugins/applitools/src/types/applitools.d.ts
+++ b/plugins/applitools/src/types/applitools.d.ts
@@ -1,4 +1,26 @@
 declare module '@applitools/eyes.webdriverio' {
+  import { BrowserType } from '@applitools/eyes-selenium';
+
+  export class Configuration {
+    public stitchMode: 'CSS';
+
+    constructor();
+
+    getBranchName(): string;
+    setBranchName(name: string): void;
+    getBaselineBranchName(): string;
+    setBaselineBranchName(name: string): void;
+    getParentBranchName(): string;
+    setParentBranchName(name: string): void;
+    setAppName(name: string): void;
+    setTestName(name: string): void;
+    setApiKey(key: string): void;
+    setForceFullPageScreenshot(force: boolean): void;
+    setHideScrollbars(hide: boolean): void;
+
+    addBrowser(width: number, height: number, browserType: BrowserType): void;
+  }
+
   export interface ViewportSize {
     width: number;
     height: number;


### PR DESCRIPTION
At some point the conf object moved to the `eyes.webdriverio` package. 

Fixes: #42 