### PR TITLE
pass port to localgrid.start

### DIFF
--- a/packages/browser/src/local-grid.ts
+++ b/packages/browser/src/local-grid.ts
@@ -8,7 +8,7 @@ export class LocalGrid {
 
   process?: Promise<ChildProcess>;
 
-  constructor(options?: { port?: number; install?: boolean }) {
+  constructor(options?: { install?: boolean }) {
     let progress: Progress;
 
     if (options && options.install) {
@@ -42,20 +42,23 @@ export class LocalGrid {
     }
   }
 
-  start(): Promise<ChildProcess> {
+  start(port: number = 4444): Promise<ChildProcess> {
     if (this.process) {
       return this.process;
     }
 
     this.process = this.install.then(() => {
       return new Promise((resolve, reject) => {
-        selenium.start((err: any, child: ChildProcess) => {
-          if (err) {
-            // return reject(err);
-          }
+        selenium.start(
+          { seleniumArgs: ['-port', `${port}`] },
+          (err: any, child: ChildProcess) => {
+            if (err) {
+              // return reject(err);
+            }
 
-          return resolve(child);
-        });
+            return resolve(child);
+          }
+        );
       });
     });
 

--- a/packages/browser/src/main.ts
+++ b/packages/browser/src/main.ts
@@ -120,15 +120,16 @@ export default class BrowserFactory {
     const { config } = this;
     logger.trace('Creating browser session', config);
     const grid = this.config.grid || 'local';
+    const browserOptions = this.getOptions(options);
     let browser;
 
     try {
       if (grid === 'local') {
-        await localGrid(true).start();
+        await localGrid(true).start(browserOptions.port);
       }
 
       const remoteOptions = this.hooks.resolveOptions.call(
-        this.getOptions(options),
+        browserOptions,
         config,
         options
       );

--- a/packages/browser/src/typings/selenium-standalone.d.ts
+++ b/packages/browser/src/typings/selenium-standalone.d.ts
@@ -1,13 +1,18 @@
 declare module 'selenium-standalone' {
-    export function install(
-      config: {
-        progressCb: (
-          totalLength: number,
-          progressLength: number,
-          chunkLength: number
-        ) => void;
-      },
-      opts?: any
-    ): any;
-    export function start(opts?: any): any;
-  }
+  import { ChildProcess } from 'child_process';
+
+  export function install(
+    config: {
+      progressCb: (
+        totalLength: number,
+        progressLength: number,
+        chunkLength: number
+      ) => void;
+    },
+    opts?: any
+  ): any;
+  export function start(
+    opts?: any,
+    cb?: (err: any, child: ChildProcess) => any
+  ): any;
+}


### PR DESCRIPTION
Okay this looks to be working. I am a selenium n00b, so guidance appreciated.  

I am passing the port to the localgrid on the call to `start` but I think it should be passed to the constructor?  I just couldn't see how to do that given that the port is not accounted for in the default export `getInstance`.  

Thanks,