### PR TITLE
Use ES5 as target for storybook plugin

### DIFF
--- a/packages/storybook/tsconfig.json
+++ b/packages/storybook/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src/**/*.ts", "../../typings/**/*"],
 
   "compilerOptions": {
+    "target": "es5",
     "outDir": "./dist",
     "rootDir": "./src"
   }


### PR DESCRIPTION
Should remove any arrow functions from the plugin to support IE11