### PR TITLE
WDIO 6.0 Fixes

### DIFF
--- a/packages/browser/src/main.ts
+++ b/packages/browser/src/main.ts
@@ -141,8 +141,8 @@ export default class BrowserFactory {
       },
       capabilities: {
         browserName: name,
-        platform,
-        version,
+        platformName: platform,
+        browserVersion: version,
         ...base.desiredCapabilities,
       },
     };

--- a/packages/browser/src/main.ts
+++ b/packages/browser/src/main.ts
@@ -187,9 +187,8 @@ export default class BrowserFactory {
 
       logger.debug(`Going to url: ${url}`);
       await browser.url(url);
-      browser.getSession().then((capabilities) => {
-        this.hooks.capabilities.call(capabilities);
-      });
+      // const capabilities = await browser.getSession();
+      // this.hooks.capabilities.call(capabilities);
 
       const session = {
         browser,
@@ -207,7 +206,9 @@ export default class BrowserFactory {
 
       if (!options.story) {
         logger.trace('Swapping to storybook iframe');
-        await browser.switchToFrame('storybook-preview-iframe');
+        await browser.switchToFrame(
+          await browser.$('#storybook-preview-iframe')
+        );
       }
 
       logger.debug('title', await browser.getTitle());

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -19,7 +19,11 @@ const defaultPlugins = [
 ];
 
 function getUrl(args: any, conf: Config): string {
-  const optUrl = args.url ?? conf.url ?? 'http://localhost';
+  if (args.url) {
+    return args.url;
+  }
+
+  const optUrl = conf.url ?? 'http://localhost';
   const port = args.port ?? conf.port;
 
   const parsed = url.parse(optUrl);


### PR DESCRIPTION
Fix some updated wdio 6 things:
- Use browserName, browserVersion, and platformName as args
- Fix iframe swap for stories


**Canary**: `0.1.1-canary.4e2c7d1.0`