### PR TITLE
Fix headless chrome arguments for `--headless` flag

### DIFF
--- a/packages/browser/src/main.ts
+++ b/packages/browser/src/main.ts
@@ -135,11 +135,11 @@ export default class BrowserFactory {
       ...base,
       sync: true,
       desiredCapabilities: {
-        chromeOptions,
         overlappingCheckDisabled: true,
         name: `${testName} - ${platform} - ${name}`,
       },
       capabilities: {
+        'goog:chromeOptions': chromeOptions,
         browserName: name,
         platformName: platform,
         browserVersion: version,


### PR DESCRIPTION
Moved the arguments for headless chrome to the capabilities section under `goog:chromeOptions`